### PR TITLE
#46 Fixed issue of parallax hero when the content was removed from homepage template

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -626,6 +626,11 @@ body:not(.page-template-template-homepage) .site-main {
 	&:not(.has-post-thumbnail) .site-main,
 	.site-main {
 		padding-top: 0;
+		@media screen and (max-width: 609px) {
+			> .sph-hero:first-child {
+				margin-top: 0;
+			}
+		}
 	}
 
 	.site-main {

--- a/style.scss
+++ b/style.scss
@@ -626,7 +626,7 @@ body:not(.page-template-template-homepage) .site-main {
 	&:not(.has-post-thumbnail) .site-main,
 	.site-main {
 		padding-top: 0;
-		@media screen and (max-width: 609px) {
+		@media screen and (max-width: 767px) {
 			> .sph-hero:first-child {
 				margin-top: 0;
 			}


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #46 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Storefront theme introduces a negative margin for the first element when there is no thumbnail, see: 
https://github.com/woocommerce/storefront-parallax-hero/blame/master/assets/css/style.scss#L12-L19

The issue is that this theme sets additional styles and they where colliding, we added a fix to avoid the hero getting this negative margin.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before
![image](https://user-images.githubusercontent.com/17932063/91732660-cf1c6880-eba8-11ea-846e-0c4cd6c8ee7b.png)

After
![image](https://user-images.githubusercontent.com/17932063/91732700-dfccde80-eba8-11ea-82b3-1dc8b6e4d171.png)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Install WP, WOO, install themes storefront and deli, install plugins storefront-parallax-hero, homepage-control.
2. Activate deli, and the plugins.
3. Create a page and set the template as homepage.
4. Set this page as frontpage
5. Open the customizer, add a parallax hero
6. Go to homepage control and remove the content


### Changelog

> Fix compatibility issue between storefront parallax hero and homepage control 

### Tests

- [x] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
