### PR TITLE
Maybe Fixes the background color of the credit card container in cart component

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -523,6 +523,10 @@ table.cart {
 	}
 }
 
+.wp-block-woocommerce-cart .wc-block-cart__submit-container {
+	background-color: #EAEAEA;
+}
+
 // Widgets
 .widget-area {
 	.widget {


### PR DESCRIPTION
… 

<!-- Reference any related issues or PRs here -->
Fixes #57 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
The background in the container is determined by the background of the theme.
See:

**storefront/inc/customizer/class-storefront-customizer.php:1009**
![image](https://user-images.githubusercontent.com/17932063/116407938-8fd71200-a832-11eb-8a70-143985ca3e79.png)


![image](https://user-images.githubusercontent.com/17932063/116407603-3838a680-a832-11eb-8da3-450d6eceb08e.png)

This issue is repeated in other themes like boutique. See: https://github.com/woocommerce/boutique/issues/81

General question -> Why not fix the source of the problem? why not delegate the responsabily of this background to the woo products blocks plugin?
https://github.com/woocommerce/woocommerce-gutenberg-products-block

This PR harcodes the background color to #EAEAEA 

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1.
2.
3.

### Changelog

> Hardcodes the background to #EAEAEA

### Tests

- [x] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
