### PR TITLE
Fixes storefront overriding wc product blocks styles

### DIFF
--- a/inc/class-deli-customizer.php
+++ b/inc/class-deli-customizer.php
@@ -36,6 +36,8 @@ class Deli_Customizer {
 		if ( version_compare( $storefront_version, '2.0.0', '<' ) ) {
 			add_action( 'init',				array( $this, 'default_theme_settings' ) );
 		}
+
+		add_filter( 'storefront_gutenberg_customizer_css', array( $this, 'remove_wc_product_block_rules' ), 10, 1);
 	}
 
 	/**
@@ -243,6 +245,14 @@ class Deli_Customizer {
 	 */
 	public function default_background_color( $color ) {
 		return '645846';
+	}
+
+    public function remove_wc_product_block_rules($styles)
+    {
+        $pattern = '/\\.wc-block-components-order-summary-item__quantity\\s\\{(.|\\s)*\\}/m';
+        $replacement = '';
+        $result = preg_replace($pattern, $replacement, $styles);
+        return $result !== null ? $result : $styles;
 	}
 }
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #58 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->

The colors used in the badge are comming from storefront.
![image](https://user-images.githubusercontent.com/17932063/116418698-abdfb100-a83c-11eb-8ed6-638562bfadcc.png)
See: https://github.com/woocommerce/storefront/blob/trunk/inc/customizer/class-storefront-customizer.php#L1016

If we remove those lines from storefront this is the result:
![image](https://user-images.githubusercontent.com/17932063/116418969-e2b5c700-a83c-11eb-867d-c7e8e3a61bb2.png)

This PR removes styles added by storefront via filter using a regular expression.

I don't like this approach because we are assuming things are there in that hook and we are parsing an string with a Regexp.

I will create another PR overriding the rules with styles in the child theme but **TBH I think this set of rules should be tackled in storefront. Maybe this set can be added with an add_filter that we can remove from the child themes.**

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before
![image](https://user-images.githubusercontent.com/17932063/116428909-a76bc600-a845-11eb-962a-7d751552bfc6.png)

After
![image](https://user-images.githubusercontent.com/17932063/116428985-b9e5ff80-a845-11eb-9875-257f9bd23ffe.png)

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1.
2.
3.

### Changelog

> Add suggested changelog entry here.

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
