### PR TITLE
Fixes Quantity badge in checkout component being ilegible via style override

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -523,6 +523,15 @@ table.cart {
 	}
 }
 
+
+// Woo Blocks
+.wp-block-woocommerce-checkout .wc-block-components-order-summary-item__quantity {
+	box-shadow: 0 0 0 2px #fff;
+	color: #000;
+	background: #fff;
+	border: 2px solid;
+}
+
 // Widgets
 .widget-area {
 	.widget {


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #58 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
See also https://github.com/woocommerce/deli/pull/61

In this PR we solve the issue via overriding the styles.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->

### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1.
2.
3.

### Changelog

> Add suggested changelog entry here.

### Tests

- [ ] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
