### PR TITLE
Fixes issue of badge having text color same as background

### DIFF
--- a/inc/class-deli-customizer.php
+++ b/inc/class-deli-customizer.php
@@ -204,6 +204,15 @@ class Deli_Customizer {
 			.order_details:after {
 				background: -webkit-linear-gradient(transparent 0,transparent 0),-webkit-linear-gradient(135deg,#ffffff 33.33%,transparent 33.33%),-webkit-linear-gradient(45deg,#ffffff 33.33%,transparent 33.33%)
 			}
+			
+			.wc-block-components-order-summary-item__quantity {
+				color: '. $button_text_color . ';
+				border-color: '. $button_text_color . ';
+			}
+			
+			.wc-block-cart__submit-container {
+				background-color: '. $button_text_color . ';
+			}
 
 			@media screen and (min-width: 768px) {
 				.deli-primary-navigation {

--- a/inc/class-deli.php
+++ b/inc/class-deli.php
@@ -28,6 +28,7 @@ class Deli {
 		add_action( 'swc_product_columns_default', array( $this, 'loop_columns' ) );
 		add_filter( 'storefront_related_products_args',	array( $this, 'related_products_args' ) );
 		add_filter( 'body_class', array( $this, 'body_classes' ) );
+		add_filter( 'storefront_gutenberg_customizer_css', array( $this, 'override_storefront_gutenberg_customizer_css' ) );
 
 		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
 			add_filter( 'storefront_loop_columns', array( $this, 'loop_columns' ) );
@@ -151,6 +152,22 @@ class Deli {
 	public function products_per_page( $per_page ) {
 		$per_page = 12;
 		return intval( $per_page );
+	}
+
+	/**
+	 * Adjust styles provided by customizer
+	 * @param $styles
+	 */
+	public function override_storefront_gutenberg_customizer_css( $styles )
+	{
+		$color = get_theme_mod('storefront_button_text_color' );
+		$styles .= "
+			.wc-block-components-order-summary-item__quantity {
+				color: {$color};
+				border-color: {$color};
+			}
+		";
+		return $styles;
 	}
 }
 


### PR DESCRIPTION
<!-- Reference any related issues or PRs here -->
Fixes #58 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Solution with instructions given in: [here](https://github.com/woocommerce/deli/pull/61#issuecomment-831348847)

<!-- Don't forget to update the title with something descriptive. -->
Fixes text not being visible when using cart component

### Screenshots
<!-- If your change has a visual component, add a screenshot here. A "before" screenshot would also be helpful. -->
Before:
![image](https://user-images.githubusercontent.com/17932063/118958711-f519b100-b961-11eb-86a4-f779d7850202.png)

After:
![image](https://user-images.githubusercontent.com/17932063/118958841-1084bc00-b962-11eb-881c-56f6a2f44176.png)



### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1.
2.
3.

### Changelog

> Fixes text not visible in badge when using cart block

### Tests

- [x] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
