### PR TITLE
Changing the color of the background of the cart block submit contain…

### DIFF
--- a/inc/class-deli.php
+++ b/inc/class-deli.php
@@ -28,6 +28,8 @@ class Deli {
 		add_action( 'swc_product_columns_default', array( $this, 'loop_columns' ) );
 		add_filter( 'storefront_related_products_args',	array( $this, 'related_products_args' ) );
 		add_filter( 'body_class', array( $this, 'body_classes' ) );
+		add_filter( 'storefront_gutenberg_customizer_css', array( $this, 'override_storefront_gutenberg_customizer_css' ), 10, 1 );
+
 
 		if ( defined( 'WC_VERSION' ) && version_compare( WC_VERSION, '3.3', '<' ) ) {
 			add_filter( 'storefront_loop_columns', array( $this, 'loop_columns' ) );
@@ -151,6 +153,21 @@ class Deli {
 	public function products_per_page( $per_page ) {
 		$per_page = 12;
 		return intval( $per_page );
+	}
+
+	/**
+	 * Adjust styles provided by customizer
+	 * @param $styles
+	 */
+	public function override_storefront_gutenberg_customizer_css( $styles )
+	{
+		$color = get_theme_mod('storefront_button_text_color' );
+		$styles .= "
+			.wc-block-cart__submit-container {
+				background-color: {$color};
+			}
+		";
+		return $styles;
 	}
 }
 


### PR DESCRIPTION
…er to the button text color

<!-- Reference any related issues or PRs here -->
Fixes #57 

<!-- Describing the changes made in this Pull Request, and the reason for such changes. -->
Changes as requested in https://github.com/woocommerce/deli/pull/60#issuecomment-831355426

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
Before:
![image](https://user-images.githubusercontent.com/17932063/118964240-96573600-b967-11eb-9067-cfb80d55be7b.png)

After:
![image](https://user-images.githubusercontent.com/17932063/118964315-abcc6000-b967-11eb-8195-05321c9306a0.png)


### How to test the changes in this Pull Request:
<!-- Add detailed instructions for how to test that this PR fixes the issue, and doesn't break any other features :) -->

1. Stripe needs to be enabled
2. Use the cart component in a page
3. 

### Changelog

> Changes the parameter for setting the background of the credit card container in the cart component

### Tests

- [x] I've tested [browser support](https://make.wordpress.org/core/handbook/best-practices/browser-support/) to ensure compatibility with >= IE11
- [ ] I've tested using only a keyboard (no mouse)
- [ ] I've tested using a screen reader
- [ ] All animations respect [`prefers-reduced-motion`](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion)
- [ ] All text has [at least a 4.5 color contrast with its background](https://webaim.org/resources/contrastchecker/)
